### PR TITLE
informiereUeberAenderung();

### DIFF
--- a/Mediathek_Vorlage_Blatt06/src/de/uni_hamburg/informatik/swt/se2/mediathek/services/verleih/VerleihServiceImpl.java
+++ b/Mediathek_Vorlage_Blatt06/src/de/uni_hamburg/informatik/swt/se2/mediathek/services/verleih/VerleihServiceImpl.java
@@ -349,6 +349,7 @@ public class VerleihServiceImpl extends AbstractObservableService
 
         _vormerkungen.put(medium, vormerkung);
 
+        informiereUeberAenderung();
     }
 
     /**


### PR DESCRIPTION
Mit diesem informiereUeberAenderung(); funktioniert die Anzeige der Vormerker in der Vormerkungsansicht und die Anzeige des ersten Vormerkers in der Ausleihanslicht. Das sich der Knopf an den richtigen Stellen, wenn man nicht ausleihen oder vormerken darf, undrückbar macht, funktionierte vorher schon.